### PR TITLE
chore: add book serializer

### DIFF
--- a/src/controllers/booksController.ts
+++ b/src/controllers/booksController.ts
@@ -1,4 +1,5 @@
 import { Response, Request } from 'express';
+import { BooksSerializer } from '../data/bookSerializer';
 import { DataBaseServices } from '../services/database.services';
 
 const ERROR_MSG = 'internal server Error';
@@ -35,13 +36,14 @@ class BooksController {
 	}
 
 	static async postBook(req: Request, res: Response) {
-		const book = req.body;
+		const bookPayload = req.body;
 		console.log( `adding new book`)
-		if (book) {
-			console.log(`New book: ${book}`);
+		if (bookPayload) {
+			const bookInitialSetUP = BooksSerializer.InitialBookObject(bookPayload)
+			console.log(`New book: ${bookInitialSetUP}`);
 			try {
 				await dataBase.connect();
-				const ret = await dataBase.insertOne(book, COLLECTION);
+				const ret = await dataBase.insertOne(bookInitialSetUP, COLLECTION);
 				await dataBase.disconnect();
 				res.status(201).send({
 					status: 'success',

--- a/src/data/bookSerializer.ts
+++ b/src/data/bookSerializer.ts
@@ -1,0 +1,30 @@
+import { bookInfo, bookObject, bookPayload, imageLinks } from "./books.interface"
+
+export class BooksSerializer {
+    static InitialBookObject(payload: bookPayload) {
+        const imageLinks: imageLinks = {
+            thumbnail: payload.coverURL,
+            mainImage: payload.coverURL
+        }
+
+        const bookInfo: bookInfo = {
+            title: payload.title,
+            subtitle: payload.subtitle,
+            mainCategory: payload.mainCategory,
+            pageCount: payload.pageCount as unknown as number,
+            authors: [payload.authors],
+            publisher: payload.publisher,
+            imageLinks: imageLinks,
+        }
+
+        const bookInitialSetUP: bookObject = {
+            short: payload.short,
+            selfLink: "",
+            avarageRating: 0,
+            ratingCount: 0,
+            bookInfo: bookInfo
+        }
+
+        return bookInitialSetUP
+    }
+}

--- a/src/data/books.interface.ts
+++ b/src/data/books.interface.ts
@@ -1,0 +1,34 @@
+
+export interface bookPayload{
+    authors: string;
+    coverURL: string;
+    mainCategory: string;
+    pageCount: string;
+    publisher: string;
+    short: string;
+    subtitle: string;
+    title: string;
+}
+
+export interface imageLinks{
+    thumbnail: string;
+    mainImage: string;
+}
+
+export interface bookInfo{
+    title: string;
+    authors: Array<string>;
+    subtitle: string;
+    mainCategory: string;
+    pageCount: number;
+    publisher: string;
+    imageLinks: imageLinks;
+}
+
+export interface bookObject{
+    short: string;
+    selfLink: string;
+    avarageRating: number;
+    ratingCount: number;
+    bookInfo: bookInfo;
+}


### PR DESCRIPTION
Adicionando um serializador pra converter o payload do front na requisição de criação de um livro para o objeto book como esta definido nas nossas documentações.
Com isso a gente consegue ir removendo regras de negocio do front e diminuir a quantidade de informação que é inserida pelo usuário no cadastro